### PR TITLE
Bump to 0.1.96

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,23 +11,23 @@ jobs:
       linux_64_python3.10.____cpython:
         CONFIG: linux_64_python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_python3.7.____73_pypy:
         CONFIG: linux_64_python3.7.____73_pypy
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_python3.7.____cpython:
         CONFIG: linux_64_python3.7.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_python3.8.____cpython:
         CONFIG: linux_64_python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_python3.9.____cpython:
         CONFIG: linux_64_python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: win
   pool:
-    vmImage: vs2017-win2016
+    vmImage: windows-2019
   strategy:
     matrix:
       win_64_python3.10.____cpython:

--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -9,7 +9,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -18,6 +18,3 @@ python:
 - 3.10.* *_cpython
 target_platform:
 - linux-64
-zip_keys:
-- - cdt_name
-  - docker_image

--- a/.ci_support/linux_64_python3.7.____73_pypy.yaml
+++ b/.ci_support/linux_64_python3.7.____73_pypy.yaml
@@ -9,7 +9,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -18,6 +18,3 @@ python:
 - 3.7.* *_73_pypy
 target_platform:
 - linux-64
-zip_keys:
-- - cdt_name
-  - docker_image

--- a/.ci_support/linux_64_python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_python3.7.____cpython.yaml
@@ -9,7 +9,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -18,6 +18,3 @@ python:
 - 3.7.* *_cpython
 target_platform:
 - linux-64
-zip_keys:
-- - cdt_name
-  - docker_image

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -9,7 +9,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -18,6 +18,3 @@ python:
 - 3.8.* *_cpython
 target_platform:
 - linux-64
-zip_keys:
-- - cdt_name
-  - docker_image

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -9,7 +9,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -18,6 +18,3 @@ python:
 - 3.9.* *_cpython
 target_platform:
 - linux-64
-zip_keys:
-- - cdt_name
-  - docker_image

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ndmaxar @oblute @rluria14 @setu4993
+* @h-vetinari @ndmaxar @oblute @rluria14 @setu4993

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -16,3 +16,4 @@ jobs:
         uses: conda-forge/automerge-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          rerendering_github_token: ${{ secrets.RERENDERING_GITHUB_TOKEN }}

--- a/.github/workflows/webservices.yml
+++ b/.github/workflows/webservices.yml
@@ -10,3 +10,4 @@ jobs:
         uses: conda-forge/webservices-dispatch-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          rerendering_github_token: ${{ secrets.RERENDERING_GITHUB_TOKEN }}

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -5,6 +5,8 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
+# -*- mode: jinja-shell -*-
+
 set -xeuo pipefail
 export FEEDSTOCK_ROOT="${FEEDSTOCK_ROOT:-/home/conda/feedstock_root}"
 source ${FEEDSTOCK_ROOT}/.scripts/logging_utils.sh
@@ -25,10 +27,10 @@ conda-build:
  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
 
 CONDARC
-GET_BOA=boa
-BUILD_CMD=mambabuild
 
-conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip ${GET_BOA:-} -c conda-forge
+
+mamba install --update-specs --yes --quiet "conda-forge-ci-setup=3" conda-build pip boa -c conda-forge
+mamba update --update-specs --yes --quiet "conda-forge-ci-setup=3" conda-build pip boa -c conda-forge
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -56,7 +58,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda $BUILD_CMD "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
     ( startgroup "Validating outputs" ) 2> /dev/null

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# -*- mode: jinja-shell -*-
+
 source .scripts/logging_utils.sh
 
 set -xe
@@ -9,7 +11,7 @@ MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
 ( startgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
 
 MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
-MINIFORGE_FILE="Miniforge3-MacOSX-$(uname -m).sh"
+MINIFORGE_FILE="Mambaforge-MacOSX-$(uname -m).sh"
 curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
 rm -rf ${MINIFORGE_HOME}
 bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
@@ -18,14 +20,12 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 
 ( startgroup "Configuring conda" ) 2> /dev/null
 
-GET_BOA=boa
-BUILD_CMD=mambabuild
-
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
 echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
-conda install -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip ${GET_BOA:-}
+mamba install -n base --update-specs --quiet --yes "conda-forge-ci-setup=3" conda-build pip boa
+mamba update -n base --update-specs --quiet --yes "conda-forge-ci-setup=3" conda-build pip boa
 
 
 
@@ -59,7 +59,7 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
     EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
 fi
 
-conda $BUILD_CMD ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
+conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
 ( startgroup "Validating outputs" ) 2> /dev/null
 
 validate_recipe_outputs "${FEEDSTOCK_NAME}"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2021, conda-forge contributors
+Copyright (c) 2015-2022, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,19 @@ Package license: Apache-2.0
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/sentencepiece-feedstock/blob/master/LICENSE.txt)
 
-Summary: SentencePiece is an unsupervised text tokenizer and detokenizer mainly for Neural Network-based text generation systems where the vocabulary size is predetermined prior to the neural model training.
+Summary: Unsupervised text tokenizer for Neural Network-based text generation.
+
+SentencePiece is an unsupervised text tokenizer and detokenizer mainly for
+Neural Network-based text generation systems where the vocabulary size is
+predetermined prior to the neural model training.
+
+SentencePiece implements subword units (e.g., byte-pair-encoding (BPE)
+[[Sennrich et al.](http://www.aclweb.org/anthology/P16-1162)]) and unigram
+language model [[Kudo](https://arxiv.org/abs/1804.109590)]) with the
+extension of direct training from raw sentences. SentencePiece allows us to
+make a purely end-to-end system that does not depend on language-specific
+pre/postprocessing.
+
 
 Current build status
 ====================
@@ -254,6 +266,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@h-vetinari](https://github.com/h-vetinari/)
 * [@ndmaxar](https://github.com/ndmaxar/)
 * [@oblute](https://github.com/oblute/)
 * [@rluria14](https://github.com/rluria14/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,3 +66,4 @@ extra:
     - rluria14
     - ndmaxar
     - oblute
+    - h-vetinari

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.95" %}
+{% set version = "0.1.96" %}
 
 package:
   name: sentencepiece
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://github.com/google/sentencepiece/archive/v{{ version }}.tar.gz
-  sha256: 1c0bd83e03f71a10fc934b7ce996e327488b838587f03159fd392c77c7701389
+  sha256: 5198f31c3bb25e685e9e68355a3bf67a1db23c9e8bdccc33dc015f496a44df7a
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,18 @@ about:
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  summary: "SentencePiece is an unsupervised text tokenizer and detokenizer mainly for Neural Network-based text generation systems where the vocabulary size is predetermined prior to the neural model training."
+  summary: Unsupervised text tokenizer for Neural Network-based text generation.
+  description: |
+    SentencePiece is an unsupervised text tokenizer and detokenizer mainly for
+    Neural Network-based text generation systems where the vocabulary size is
+    predetermined prior to the neural model training.
+
+    SentencePiece implements subword units (e.g., byte-pair-encoding (BPE)
+    [[Sennrich et al.](http://www.aclweb.org/anthology/P16-1162)]) and unigram
+    language model [[Kudo](https://arxiv.org/abs/1804.109590)]) with the
+    extension of direct training from raw sentences. SentencePiece allows us to
+    make a purely end-to-end system that does not depend on language-specific
+    pre/postprocessing.
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Breaking this out of #26 because the version bump shouldn't be tied to the library untangling. Also, need for the package came up in https://github.com/conda-forge/tango-feedstock/pull/2